### PR TITLE
Stop the header height lifting the tile row off the screen edge

### DIFF
--- a/dashboards/templates/includes/hemma_screen_layout.yaml
+++ b/dashboards/templates/includes/hemma_screen_layout.yaml
@@ -4,7 +4,8 @@ grid-column-gap: 0px
 margin: 0
 padding: 0
 position: relative
-min-height: calc(100svh - var(--hemma-header-offset, 0px))
+# Header floats over the view; subtracting its height strands the tile row.
+min-height: 100svh
 
 mediaquery:
   "(max-width: 767px) and (orientation: portrait), (max-height: 500px) and (orientation: portrait)":


### PR DESCRIPTION
The lovelace header paints over the view rather than displacing it, so subtracting its height from the view min-height left the whole layout 56px short while its content still started at the top. The entity row is anchored to the view's bottom, so it floated 96px above the screen edge instead of 40px.

Only visible on shorter tablets, where --hero-top and --hemma-header-cap-tablet are already at their clamp floors and had no slack to absorb it.

Fixes #58